### PR TITLE
feat: invert skill_level scale logic

### DIFF
--- a/frontend/src/__tests__/components/Analysis.risk-calculations.test.js
+++ b/frontend/src/__tests__/components/Analysis.risk-calculations.test.js
@@ -261,18 +261,18 @@ describe('Analysis Component - Risk Calculations', () => {
     });
 
     test('should handle skill level scale correctly', () => {
-      // Test that the inverted skill level scale works correctly
+      // Test that the skill level scale works correctly
       const skillLevelDescriptions = {
-        1: 'Habilidades de penetración de seguridad', // Lowest risk (expert required)
-        3: 'Habilidades de red y programación',
+        1: 'Sin habilidades técnicas', // Highest risk (anyone can do it)
+        3: 'Algunas habilidades técnicas',
         5: 'Usuario avanzado de computadoras',
-        6: 'Algunas habilidades técnicas',
-        9: 'Sin habilidades técnicas' // Highest risk (anyone can do it)
+        6: 'Habilidades de red y programación',
+        9: 'Habilidades de penetración de seguridad' // Lowest risk (expert required)
       };
 
-      // Verify the scale is inverted (higher value = easier to execute = higher risk)
-      expect(skillLevelDescriptions[9]).toContain('Sin habilidades');
-      expect(skillLevelDescriptions[1]).toContain('penetración');
+      // Verify the scale (higher value = more skills required = lower risk)
+      expect(skillLevelDescriptions[1]).toContain('Sin habilidades');
+      expect(skillLevelDescriptions[9]).toContain('penetración');
     });
   });
 

--- a/frontend/src/__tests__/hooks/useLocalization.test.js
+++ b/frontend/src/__tests__/hooks/useLocalization.test.js
@@ -73,11 +73,11 @@ describe('getOwaspSelectOptions', () => {
       values: {
         skill_level: {
           "0": "N/A",
-          "1": "Habilidades de penetración de seguridad",
-          "3": "Habilidades de red y programación",
+          "1": "Sin habilidades técnicas",
+          "3": "Algunas habilidades técnicas",
           "5": "Usuario avanzado de computadoras",
-          "6": "Algunas habilidades técnicas", 
-          "9": "Sin habilidades técnicas"
+          "6": "Habilidades de red y programación", 
+          "9": "Habilidades de penetración de seguridad"
         },
         motive: {
           "0": "N/A",
@@ -99,7 +99,7 @@ describe('getOwaspSelectOptions', () => {
     });
     expect(options[5]).toEqual({
       value: 9,
-      label: '9 - Sin habilidades técnicas'
+      label: '9 - Habilidades de penetración de seguridad'
     });
   });
 

--- a/frontend/src/__tests__/integration/Analysis.integration.test.js
+++ b/frontend/src/__tests__/integration/Analysis.integration.test.js
@@ -62,11 +62,11 @@ jest.mock('../../hooks/useLocalization', () => ({
     changeLanguage: jest.fn()
   }),
   getOwaspSelectOptions: jest.fn().mockReturnValue([
-    { value: 1, label: '1 - Habilidades de penetración de seguridad' },
-    { value: 3, label: '3 - Habilidades de red y programación' },
+    { value: 1, label: '1 - Sin habilidades técnicas' },
+    { value: 3, label: '3 - Algunas habilidades técnicas' },
     { value: 5, label: '5 - Usuario avanzado de computadoras' },
-    { value: 6, label: '6 - Algunas habilidades técnicas' },
-    { value: 9, label: '9 - Sin habilidades técnicas' }
+    { value: 6, label: '6 - Habilidades de red y programación' },
+    { value: 9, label: '9 - Habilidades de penetración de seguridad' }
   ])
 }));
 

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -27,11 +27,11 @@
     "values": {
       "skill_level": {
         "0": "N/A",
-        "1": "Security penetration skills",
-        "3": "Network and programming skills",
+        "1": "No technical skills",
+        "3": "Some technical skills",
         "5": "Advanced computer user",
-        "6": "Some technical skills",
-        "9": "No technical skills"
+        "6": "Network and programming skills",
+        "9": "Security penetration skills"
       },
       "motive": {
         "0": "N/A",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -27,11 +27,11 @@
     "values": {
       "skill_level": {
         "0": "N/A",
-        "1": "Habilidades de penetración de seguridad",
-        "3": "Habilidades de red y programación",
+        "1": "Sin habilidades técnicas",
+        "3": "Algunas habilidades técnicas",
         "5": "Usuario avanzado de computadoras",
-        "6": "Algunas habilidades técnicas",
-        "9": "Sin habilidades técnicas"
+        "6": "Habilidades de red y programación",
+        "9": "Habilidades de penetración de seguridad"
       },
       "motive": {
         "0": "N/A",


### PR DESCRIPTION
- Change skill_level scale: 1=No technical skills, 9=Security penetration skills
- Update Spanish and English translations in locales
- Fix all related tests to reflect new scale
- Add documentation comments explaining the new scale
- Maintain OWASP Risk Rating calculation compatibility

This makes the skill level more intuitive where higher values represent higher skill requirements (lower risk).