### PR TITLE
Potential fix for code scanning alert no. 7: Information exposure through an exception

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -13,6 +13,7 @@ This module contains all the REST API endpoints organized by functional domains:
 
 import os
 import json
+import logging
 from uuid import UUID
 from datetime import datetime, timedelta
 from typing import List, Optional, Dict, Any
@@ -25,6 +26,8 @@ from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from pydantic import BaseModel
 from sqlalchemy.orm import Session, joinedload
 from jose import JWTError, jwt
+
+logger = logging.getLogger(__name__)
 
 # Configure timezone from environment variable
 if 'TZ' in os.environ:
@@ -556,8 +559,9 @@ async def evaluate_system_diagram(
         }
     
     except Exception as e:
+        logger.exception("Error during system diagram evaluation")
         return {
-            "message": f"Error during processing: {str(e)}", 
+            "message": "An internal error occurred during diagram processing.",
             "success": False
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/drneox/tzu/security/code-scanning/7](https://github.com/drneox/tzu/security/code-scanning/7)

To fix this safely, keep the existing endpoint behavior (`success: False` on failure) but stop returning raw exception data. Replace the client-facing message with a generic error string, and log the real exception server-side for diagnostics.

Best single fix in `api/api.py`:
1. Add a standard logger (`import logging` and `logger = logging.getLogger(__name__)`) near imports/module setup.
2. In the `except Exception as e:` block of `evaluate_system_diagram`, log with `logger.exception(...)` (captures traceback server-side) and return a sanitized response:
   - `"message": "An internal error occurred during diagram processing."`
   - `"success": False`

This preserves API contract shape while removing sensitive data exposure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
