### PR TITLE
feat: project grouping for analyses (#002)

### DIFF
--- a/api/alembic/versions/add_diagram_input_type_to_information_systems.py
+++ b/api/alembic/versions/add_diagram_input_type_to_information_systems.py
@@ -1,7 +1,7 @@
 """Add diagram_input_type to information_systems
 
 Revision ID: add_diagram_input_type
-Revises: add_control_tags_simple
+Revises: add_audit_logs_table
 Create Date: 2026-05-23 00:00:00.000000
 
 """
@@ -9,7 +9,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision = 'add_diagram_input_type'
-down_revision = 'add_control_tags_simple'
+down_revision = 'add_audit_logs_table'
 branch_labels = None
 depends_on = None
 

--- a/api/alembic/versions/add_projects_and_members.py
+++ b/api/alembic/versions/add_projects_and_members.py
@@ -1,0 +1,56 @@
+"""Add projects and project_members tables, project_id FK on information_systems
+
+Revision ID: add_projects_and_members
+Revises: add_diagram_input_type
+Create Date: 2026-05-31 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'add_projects_and_members'
+down_revision = 'add_diagram_input_type'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'projects',
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('description', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('created_by', sa.UUID(), nullable=False),
+        sa.ForeignKeyConstraint(['created_by'], ['users.id']),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_table(
+        'project_members',
+        sa.Column('project_id', sa.UUID(), nullable=False),
+        sa.Column('user_id', sa.UUID(), nullable=False),
+        sa.Column('added_at', sa.DateTime(), nullable=True),
+        sa.Column('added_by', sa.UUID(), nullable=True),
+        sa.ForeignKeyConstraint(['added_by'], ['users.id']),
+        sa.ForeignKeyConstraint(['project_id'], ['projects.id']),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id']),
+        sa.PrimaryKeyConstraint('project_id', 'user_id')
+    )
+    op.add_column(
+        'information_systems',
+        sa.Column('project_id', sa.UUID(), nullable=True)
+    )
+    op.create_foreign_key(
+        'fk_is_project',
+        'information_systems', 'projects',
+        ['project_id'], ['id'],
+        ondelete='SET NULL'
+    )
+
+
+def downgrade():
+    op.drop_constraint('fk_is_project', 'information_systems', type_='foreignkey')
+    op.drop_column('information_systems', 'project_id')
+    op.drop_table('project_members')
+    op.drop_table('projects')

--- a/api/api.py
+++ b/api/api.py
@@ -20,6 +20,7 @@ from typing import List, Optional, Dict, Any
 
 # Third-party imports
 from fastapi import FastAPI, HTTPException, Depends, UploadFile, Body, Form, status, Path, Query
+from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
@@ -506,22 +507,17 @@ async def get_audit_log(
 async def read_information_systems(
     skip: int = Query(0, ge=0, description="Number of records to skip"),
     limit: int = Query(100, ge=1, le=1000, description="Maximum number of records to return"),
+    project_id: Optional[str] = Query(None, description="Filter by project UUID"),
     db: Session = Depends(get_db), 
     current_user: models.User = Depends(get_current_active_user)
 ):
     """
     Retrieve list of information systems with pagination.
-    
-    Args:
-        skip: Number of records to skip for pagination
-        limit: Maximum number of records to return
-        db: Database session
-        current_user: Current authenticated user
-        
-    Returns:
-        List[schemas.InformationSystem]: List of information systems
     """
-    information_systems = crud.get_information_systems(db, skip=skip, limit=limit)
+    filter_project_id = None
+    if project_id is not None:
+        filter_project_id = validate_uuid(project_id, "project_id")
+    information_systems = crud.get_information_systems(db, skip=skip, limit=limit, project_id=filter_project_id)
     return information_systems
 
 @app.get(
@@ -572,20 +568,12 @@ async def read_information_system(
     description="Create a new information system"
 )
 async def create_information_system(
-    information_system: schemas.InformationSystemBaseCreate, 
+    information_system: schemas.InformationSystemCreate, 
     db: Session = Depends(get_db), 
     current_user: models.User = Depends(require_analyst_user)
 ):
     """
     Create a new information system.
-    
-    Args:
-        information_system: Information system data
-        db: Database session
-        current_user: Current authenticated user
-        
-    Returns:
-        schemas.InformationSystem: Created information system
     """
     db_information_system = crud.create_information_system(
         db, 
@@ -1673,10 +1661,238 @@ async def delete_remediation(
     return {"message": "Remediation deleted successfully"}
 
 # =====================================================
-# ERROR HANDLERS & MIDDLEWARE
+# PROJECTS ENDPOINTS
 # =====================================================
 
-from fastapi.responses import JSONResponse
+@app.get(
+    "/projects",
+    response_model=List[schemas.ProjectWithCounts],
+    tags=["Projects"],
+    summary="List Projects",
+    description="Get list of all projects with analysis and member counts"
+)
+async def list_projects(
+    skip: int = Query(0, ge=0),
+    limit: int = Query(100, ge=1, le=1000),
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_active_user),
+):
+    projects = crud.get_projects(db, skip=skip, limit=limit)
+    result = []
+    for p in projects:
+        result.append(schemas.ProjectWithCounts(
+            id=p.id,
+            name=p.name,
+            description=p.description,
+            created_at=p.created_at,
+            created_by=p.created_by,
+            analysis_count=getattr(p, "_analysis_count", 0),
+            member_count=getattr(p, "_member_count", 0),
+        ))
+    return result
+
+
+@app.post(
+    "/projects",
+    response_model=schemas.ProjectResponse,
+    status_code=status.HTTP_201_CREATED,
+    tags=["Projects"],
+    summary="Create Project",
+    description="Create a new project (analyst or admin only)"
+)
+async def create_project_endpoint(
+    project: schemas.ProjectCreate,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(require_analyst_user),
+):
+    if not project.name or not project.name.strip():
+        raise HTTPException(status_code=400, detail="Project name cannot be empty")
+    if len(project.name.strip()) > 120:
+        raise HTTPException(status_code=400, detail="Project name too long (max 120 chars)")
+    return crud.create_project(db, project=project, created_by=current_user.id)
+
+
+@app.get(
+    "/projects/{project_id}",
+    response_model=schemas.ProjectWithCounts,
+    tags=["Projects"],
+    summary="Get Project",
+    description="Get a single project by ID"
+)
+async def get_project_endpoint(
+    project_id: str = Path(..., description="Project UUID"),
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_active_user),
+):
+    pid = validate_uuid(project_id, "project ID")
+    project = crud.get_project(db, project_id=pid)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    return schemas.ProjectWithCounts(
+        id=project.id,
+        name=project.name,
+        description=project.description,
+        created_at=project.created_at,
+        created_by=project.created_by,
+        analysis_count=getattr(project, "_analysis_count", 0),
+        member_count=getattr(project, "_member_count", 0),
+    )
+
+
+@app.put(
+    "/projects/{project_id}",
+    response_model=schemas.ProjectWithCounts,
+    tags=["Projects"],
+    summary="Update Project",
+    description="Update project name/description (owner or admin only)"
+)
+async def update_project_endpoint(
+    project_id: str = Path(..., description="Project UUID"),
+    data: schemas.ProjectUpdate = Body(...),
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_active_user),
+):
+    pid = validate_uuid(project_id, "project ID")
+    project, error = crud.update_project(db, project_id=pid, data=data, current_user=current_user)
+    if error == "not_found":
+        raise HTTPException(status_code=404, detail="Project not found")
+    if error == "forbidden":
+        raise HTTPException(status_code=403, detail="Only the project creator or an admin can update this project")
+    if error == "empty_name":
+        raise HTTPException(status_code=400, detail="Project name cannot be empty")
+    project = crud.get_project(db, project_id=pid)
+    return schemas.ProjectWithCounts(
+        id=project.id,
+        name=project.name,
+        description=project.description,
+        created_at=project.created_at,
+        created_by=project.created_by,
+        analysis_count=getattr(project, "_analysis_count", 0),
+        member_count=getattr(project, "_member_count", 0),
+    )
+
+
+@app.delete(
+    "/projects/{project_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    tags=["Projects"],
+    summary="Delete Project",
+    description="Delete a project (owner or admin only)"
+)
+async def delete_project_endpoint(
+    project_id: str = Path(..., description="Project UUID"),
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_active_user),
+):
+    pid = validate_uuid(project_id, "project ID")
+    ok, error = crud.delete_project(db, project_id=pid, current_user=current_user)
+    if error == "not_found":
+        raise HTTPException(status_code=404, detail="Project not found")
+    if error == "forbidden":
+        raise HTTPException(status_code=403, detail="Only the project creator or an admin can delete this project")
+
+
+@app.get(
+    "/projects/{project_id}/members",
+    response_model=List[schemas.ProjectMemberBase],
+    tags=["Projects"],
+    summary="List Project Members",
+    description="List members of a project (owner or admin only)"
+)
+async def list_project_members(
+    project_id: str = Path(..., description="Project UUID"),
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_active_user),
+):
+    pid = validate_uuid(project_id, "project ID")
+    members, error = crud.get_project_members(db, project_id=pid, current_user=current_user)
+    if error == "not_found":
+        raise HTTPException(status_code=404, detail="Project not found")
+    if error == "forbidden":
+        raise HTTPException(status_code=403, detail="Only the project creator or an admin can view members")
+    return [schemas.ProjectMemberBase(**m) for m in members]
+
+
+@app.post(
+    "/projects/{project_id}/members",
+    response_model=schemas.ProjectMemberBase,
+    status_code=status.HTTP_201_CREATED,
+    tags=["Projects"],
+    summary="Add Project Member",
+    description="Add a user as a member of a project (owner or admin only)"
+)
+async def add_project_member_endpoint(
+    project_id: str = Path(..., description="Project UUID"),
+    body: schemas.ProjectMemberAdd = Body(...),
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_active_user),
+):
+    pid = validate_uuid(project_id, "project ID")
+    member, error = crud.add_project_member(
+        db,
+        project_id=pid,
+        user_id=body.user_id,
+        added_by=current_user.id,
+        current_user=current_user,
+    )
+    if error == "not_found":
+        raise HTTPException(status_code=404, detail="Project not found")
+    if error == "forbidden":
+        raise HTTPException(status_code=403, detail="Only the project creator or an admin can add members")
+    if error == "user_not_found":
+        raise HTTPException(status_code=400, detail="User not found")
+    if error == "already_member":
+        raise HTTPException(status_code=409, detail="User is already a member of this project")
+    return schemas.ProjectMemberBase(**member)
+
+
+@app.delete(
+    "/projects/{project_id}/members/{user_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    tags=["Projects"],
+    summary="Remove Project Member",
+    description="Remove a user from a project (owner or admin only)"
+)
+async def remove_project_member_endpoint(
+    project_id: str = Path(..., description="Project UUID"),
+    user_id: str = Path(..., description="User UUID"),
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_active_user),
+):
+    pid = validate_uuid(project_id, "project ID")
+    uid = validate_uuid(user_id, "user ID")
+    ok, error = crud.remove_project_member(db, project_id=pid, user_id=uid, current_user=current_user)
+    if error == "not_found":
+        raise HTTPException(status_code=404, detail="Project or membership not found")
+    if error == "forbidden":
+        raise HTTPException(status_code=403, detail="Only the project creator or an admin can remove members")
+
+
+@app.put(
+    "/information_systems/{information_system_id}",
+    response_model=schemas.InformationSystem,
+    tags=["Information Systems"],
+    summary="Update Information System",
+    description="Update title, description, or project assignment of an information system (owner or admin only)"
+)
+async def update_information_system_endpoint(
+    information_system_id: str = Path(..., description="Information system UUID"),
+    data: schemas.InformationSystemUpdate = Body(...),
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(require_analyst_user),
+):
+    system_uuid = validate_uuid(information_system_id, "information system ID")
+    system, error = crud.update_information_system(db, str(system_uuid), data, current_user)
+    if error == "not_found":
+        raise HTTPException(status_code=404, detail="Information system not found")
+    if error == "forbidden":
+        raise HTTPException(status_code=403, detail="You can only update information systems you created")
+    return system
+
+
+# =====================================================
+# ERROR HANDLERS & MIDDLEWARE
+# =====================================================
 
 @app.exception_handler(404)
 async def not_found_handler(request, exc):

--- a/api/crud.py
+++ b/api/crud.py
@@ -356,8 +356,11 @@ def update_threat_risk(db: Session, threat_id: str, data: dict):
         db.refresh(remediation)
     return threat
 
-def get_information_systems(db: Session,skip: int = 0, limit: int = 100):
-    return db.query(models.InformationSystem).order_by(models.InformationSystem.datetime.desc()).offset(skip).limit(limit).all()
+def get_information_systems(db: Session, skip: int = 0, limit: int = 100, project_id: Optional[UUID] = None):
+    query = db.query(models.InformationSystem)
+    if project_id is not None:
+        query = query.filter(models.InformationSystem.project_id == project_id)
+    return query.order_by(models.InformationSystem.datetime.desc()).offset(skip).limit(limit).all()
  
 def get_information_system(db: Session, information_system_id: str):
     return db.query(models.InformationSystem).options(
@@ -371,12 +374,25 @@ def get_threats_by_information_system(db: Session, information_system_id: str):
         joinedload(models.Threat.remediation)
     ).filter(models.Threat.information_system_id == UUID(information_system_id)).order_by(models.Threat.created_at.desc()).all()
  
-def create_information_system(db: Session, information_system: schemas.InformationSystem, created_by=None):
-    db_information_system = models.InformationSystem(title=information_system.title,
-                                                    description=information_system.description,
-                                                    created_by=created_by
-                                                    )
-    
+def create_information_system(db: Session, information_system: schemas.InformationSystemCreate, created_by=None):
+    project_id = information_system.project_id
+    # If project_name is provided (and no project_id), always create a new project
+    if information_system.project_name and not project_id:
+        if created_by is None:
+            raise ValueError("created_by is required when project_name is provided")
+        new_project = create_project_by_name(
+            db,
+            name=information_system.project_name,
+            created_by=created_by
+        )
+        project_id = new_project.id
+
+    db_information_system = models.InformationSystem(
+        title=information_system.title,
+        description=information_system.description,
+        created_by=created_by,
+        project_id=project_id,
+    )
     db.add(db_information_system)
     db.commit()
     db.refresh(db_information_system)
@@ -621,3 +637,208 @@ def delete_threat(db: Session, threat_id: str):
     db.commit()
     return True
 
+
+
+# =====================================================
+# PROJECT CRUD FUNCTIONS
+# =====================================================
+
+def create_project(db: Session, project: schemas.ProjectCreate, created_by) -> models.Project:
+    db_project = models.Project(
+        name=project.name.strip(),
+        description=project.description,
+        created_by=created_by,
+    )
+    db.add(db_project)
+    db.commit()
+    db.refresh(db_project)
+    return db_project
+
+
+def create_project_by_name(db: Session, name: str, created_by) -> models.Project:
+    """Always creates a new project with the given name (no lookup). See research.md Decision 4."""
+    db_project = models.Project(
+        name=name.strip(),
+        created_by=created_by,
+    )
+    db.add(db_project)
+    db.commit()
+    db.refresh(db_project)
+    return db_project
+
+
+def get_projects(db: Session, skip: int = 0, limit: int = 100):
+    from sqlalchemy import func, select
+    analysis_count_sub = (
+        select(func.count())
+        .where(models.InformationSystem.project_id == models.Project.id)
+        .correlate(models.Project)
+        .scalar_subquery()
+    )
+    member_count_sub = (
+        select(func.count())
+        .where(models.ProjectMember.project_id == models.Project.id)
+        .correlate(models.Project)
+        .scalar_subquery()
+    )
+    rows = (
+        db.query(
+            models.Project,
+            analysis_count_sub.label("analysis_count"),
+            member_count_sub.label("member_count"),
+        )
+        .order_by(models.Project.created_at.desc())
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
+    results = []
+    for project, ac, mc in rows:
+        project._analysis_count = ac
+        project._member_count = mc
+        results.append(project)
+    return results
+
+
+def get_project(db: Session, project_id) -> Optional[models.Project]:
+    from sqlalchemy import func, select
+    project = db.query(models.Project).filter(models.Project.id == project_id).first()
+    if project is None:
+        return None
+    project._analysis_count = db.query(models.InformationSystem).filter(
+        models.InformationSystem.project_id == project_id
+    ).count()
+    project._member_count = db.query(models.ProjectMember).filter(
+        models.ProjectMember.project_id == project_id
+    ).count()
+    return project
+
+
+def update_project(db: Session, project_id, data: schemas.ProjectUpdate, current_user: models.User) -> Optional[models.Project]:
+    project = db.query(models.Project).filter(models.Project.id == project_id).first()
+    if project is None:
+        return None, "not_found"
+    if str(project.created_by) != str(current_user.id) and current_user.role != "admin":
+        return None, "forbidden"
+    if data.name is not None:
+        name = data.name.strip()
+        if not name:
+            return None, "empty_name"
+        project.name = name
+    if data.description is not None:
+        project.description = data.description
+    db.commit()
+    db.refresh(project)
+    return project, None
+
+
+def delete_project(db: Session, project_id, current_user: models.User):
+    project = db.query(models.Project).filter(models.Project.id == project_id).first()
+    if project is None:
+        return False, "not_found"
+    if str(project.created_by) != str(current_user.id) and current_user.role != "admin":
+        return False, "forbidden"
+    db.delete(project)
+    db.commit()
+    return True, None
+
+
+def update_information_system(db: Session, information_system_id: str, data: schemas.InformationSystemUpdate, current_user: models.User):
+    system = db.query(models.InformationSystem).filter(
+        models.InformationSystem.id == UUID(information_system_id)
+    ).first()
+    if system is None:
+        return None, "not_found"
+    if str(system.created_by) != str(current_user.id) and current_user.role != "admin":
+        return None, "forbidden"
+    if data.title is not None:
+        system.title = data.title
+    if data.description is not None:
+        system.description = data.description
+    if data.project_name_inline:
+        new_project = create_project_by_name(db, name=data.project_name_inline, created_by=current_user.id)
+        system.project_id = new_project.id
+    elif "project_id" in data.model_fields_set:
+        system.project_id = data.project_id
+    db.commit()
+    db.refresh(system)
+    return system, None
+
+
+# =====================================================
+# PROJECT MEMBER CRUD FUNCTIONS
+# =====================================================
+
+def get_project_members(db: Session, project_id, current_user: models.User):
+    project = db.query(models.Project).filter(models.Project.id == project_id).first()
+    if project is None:
+        return None, "not_found"
+    if str(project.created_by) != str(current_user.id) and current_user.role != "admin":
+        return None, "forbidden"
+    members = (
+        db.query(models.ProjectMember, models.User)
+        .join(models.User, models.User.id == models.ProjectMember.user_id)
+        .filter(models.ProjectMember.project_id == project_id)
+        .all()
+    )
+    result = []
+    for membership, user in members:
+        result.append({
+            "user_id": user.id,
+            "username": user.username,
+            "name": user.name,
+            "role": user.role,
+            "added_at": membership.added_at,
+            "added_by": membership.added_by,
+        })
+    return result, None
+
+
+def add_project_member(db: Session, project_id, user_id, added_by, current_user: models.User):
+    project = db.query(models.Project).filter(models.Project.id == project_id).first()
+    if project is None:
+        return None, "not_found"
+    if str(project.created_by) != str(current_user.id) and current_user.role != "admin":
+        return None, "forbidden"
+    target_user = db.query(models.User).filter(models.User.id == user_id).first()
+    if target_user is None:
+        return None, "user_not_found"
+    existing = db.query(models.ProjectMember).filter(
+        models.ProjectMember.project_id == project_id,
+        models.ProjectMember.user_id == user_id,
+    ).first()
+    if existing:
+        return None, "already_member"
+    membership = models.ProjectMember(
+        project_id=project_id,
+        user_id=user_id,
+        added_by=added_by,
+    )
+    db.add(membership)
+    db.commit()
+    db.refresh(membership)
+    return {
+        "user_id": target_user.id,
+        "username": target_user.username,
+        "name": target_user.name,
+        "role": target_user.role,
+        "added_at": membership.added_at,
+        "added_by": membership.added_by,
+    }, None
+
+
+def remove_project_member(db: Session, project_id, user_id, current_user: models.User):
+    project = db.query(models.Project).filter(models.Project.id == project_id).first()
+    if project is None:
+        return False, "not_found"
+    if str(project.created_by) != str(current_user.id) and current_user.role != "admin":
+        return False, "forbidden"
+    membership = db.query(models.ProjectMember).filter(
+        models.ProjectMember.project_id == project_id,
+        models.ProjectMember.user_id == user_id,
+    ).first()
+    if membership is None:
+        return False, "not_found"
+    db.delete(membership)
+    db.commit()
+    return True, None

--- a/api/models.py
+++ b/api/models.py
@@ -195,6 +195,31 @@ class Threat(Base):
             return "UNKNOWN"
     
     
+class Project(Base):
+    __tablename__ = "projects"
+    id = Column(UUID, primary_key=True, default=uuid.uuid4)
+    name = Column(String, nullable=False)
+    description = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=datetime.datetime.utcnow)
+    created_by = Column(UUID, ForeignKey("users.id"), nullable=False)
+
+    creator = relationship("User", foreign_keys=[created_by], back_populates="projects")
+    members = relationship("ProjectMember", back_populates="project", cascade="all, delete-orphan")
+    information_systems = relationship("InformationSystem", back_populates="project")
+
+
+class ProjectMember(Base):
+    __tablename__ = "project_members"
+    project_id = Column(UUID, ForeignKey("projects.id"), primary_key=True)
+    user_id = Column(UUID, ForeignKey("users.id"), primary_key=True)
+    added_at = Column(DateTime, default=datetime.datetime.utcnow)
+    added_by = Column(UUID, ForeignKey("users.id"), nullable=True)
+
+    project = relationship("Project", back_populates="members")
+    user = relationship("User", foreign_keys=[user_id], back_populates="project_memberships")
+    adder = relationship("User", foreign_keys=[added_by])
+
+
 class InformationSystem(Base):
     __tablename__ = "information_systems"
     id = Column(UUID, primary_key=True, default=uuid.uuid4)
@@ -202,9 +227,16 @@ class InformationSystem(Base):
     description = Column(Text)
     datetime = Column(DateTime, default=datetime.datetime.utcnow)
     diagram = Column(Text)
+    diagram_input_type = Column(String, nullable=True)
     created_by = Column(UUID, ForeignKey("users.id"), nullable=True)
+    project_id = Column(UUID, ForeignKey("projects.id", ondelete="SET NULL"), nullable=True)
 
     threats = relationship("Threat", back_populates="information_system", cascade="all, delete-orphan")
+    project = relationship("Project", back_populates="information_systems")
+
+    @property
+    def project_name(self):
+        return self.project.name if self.project else None
 
 
 class UseCase(Base):
@@ -228,6 +260,9 @@ class User(Base):
     is_active = Column(Boolean, default=True)
     is_admin = Column(Boolean, default=False)
     role = Column(String, default="reader")
+
+    projects = relationship("Project", back_populates="creator", foreign_keys="Project.created_by")
+    project_memberships = relationship("ProjectMember", back_populates="user", foreign_keys="ProjectMember.user_id")
 
 
 class AuditLog(Base):

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -199,7 +199,6 @@ class AuditLogEntry(BaseModel):
     performed_by_id: UUID
     timestamp: datetime
     detail: Optional[str] = None
-    password: str
 
 
 # =====================================================

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -8,11 +8,15 @@ import json
 class InformationSystemCreate(BaseModel):
     title: str
     description: str | None = None
+    project_id: Optional[UUID] = None
+    project_name: Optional[str] = None
 
 class InformationSystemBase(BaseModel):
     id: UUID
     title: str
     description: str | None = None
+    project_id: Optional[UUID] = None
+    project_name: Optional[str] = None
   
 
 class InformationSystemBaseCreate(InformationSystemCreate):
@@ -196,3 +200,60 @@ class AuditLogEntry(BaseModel):
     timestamp: datetime
     detail: Optional[str] = None
     password: str
+
+
+# =====================================================
+# PROJECT SCHEMAS
+# =====================================================
+
+class ProjectBase(BaseModel):
+    name: str
+    description: Optional[str] = None
+
+
+class ProjectCreate(ProjectBase):
+    pass
+
+
+class ProjectUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+
+
+class ProjectResponse(ProjectBase):
+    model_config = {"from_attributes": True}
+
+    id: UUID
+    created_at: datetime
+    created_by: UUID
+
+
+class ProjectWithCounts(ProjectResponse):
+    analysis_count: int = 0
+    member_count: int = 0
+
+
+class ProjectMemberAdd(BaseModel):
+    user_id: UUID
+
+
+class ProjectMemberBase(BaseModel):
+    model_config = {"from_attributes": True}
+
+    user_id: UUID
+    username: str
+    name: str
+    role: str
+    added_at: datetime
+    added_by: Optional[UUID] = None
+
+
+# =====================================================
+# INFORMATION SYSTEM UPDATE SCHEMA
+# =====================================================
+
+class InformationSystemUpdate(BaseModel):
+    title: Optional[str] = None
+    description: Optional[str] = None
+    project_id: Optional[UUID] = None
+    project_name_inline: Optional[str] = None  # Creates a new project inline if provided

--- a/api/tests/test_information_system_endpoints.py
+++ b/api/tests/test_information_system_endpoints.py
@@ -84,8 +84,8 @@ class TestInformationSystemEndpoints:
             json=update_data, 
             headers=auth_headers
         )
-        # Note: PUT endpoint may not exist, expect 405 Method Not Allowed
-        assert response.status_code in [200, 405]
+        # PUT endpoint exists but requires analyst role; reader user gets 403
+        assert response.status_code in [200, 403, 405]
     
     def test_delete_information_system(self, admin_auth_headers):
         """Test eliminar sistema de información (requires analyst or admin role)"""

--- a/api/tests/test_project_members_endpoints.py
+++ b/api/tests/test_project_members_endpoints.py
@@ -1,0 +1,186 @@
+"""
+Tests for project members endpoints
+"""
+import pytest
+import uuid
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _create_project(client, headers, name=None):
+    name = name or f"MP-{uuid.uuid4().hex[:8]}"
+    resp = client.post("/projects", json={"name": name}, headers=headers)
+    assert resp.status_code == 201
+    return resp.json()
+
+
+# ===========================================================================
+# LIST MEMBERS
+# ===========================================================================
+
+class TestListMembers:
+    def test_list_requires_auth(self, test_client, analyst_auth_headers):
+        proj = _create_project(test_client, analyst_auth_headers)
+        resp = test_client.get(f"/projects/{proj['id']}/members")
+        assert resp.status_code == 401
+
+    def test_list_empty_initially(self, test_client, analyst_auth_headers):
+        proj = _create_project(test_client, analyst_auth_headers)
+        resp = test_client.get(f"/projects/{proj['id']}/members", headers=analyst_auth_headers)
+        assert resp.status_code == 200
+        assert isinstance(resp.json(), list)
+
+    def test_list_non_owner_forbidden(self, test_client, analyst_auth_headers, auth_headers):
+        proj = _create_project(test_client, analyst_auth_headers)
+        resp = test_client.get(f"/projects/{proj['id']}/members", headers=auth_headers)
+        assert resp.status_code == 403
+
+    def test_list_nonexistent_project(self, test_client, analyst_auth_headers):
+        fake_id = str(uuid.uuid4())
+        resp = test_client.get(f"/projects/{fake_id}/members", headers=analyst_auth_headers)
+        assert resp.status_code == 404
+
+
+# ===========================================================================
+# ADD MEMBER
+# ===========================================================================
+
+class TestAddMember:
+    def test_add_requires_auth(self, test_client, analyst_auth_headers):
+        proj = _create_project(test_client, analyst_auth_headers)
+        resp = test_client.post(f"/projects/{proj['id']}/members", json={"user_id": str(uuid.uuid4())})
+        assert resp.status_code == 401
+
+    def test_add_non_owner_forbidden(self, test_client, analyst_auth_headers, auth_headers, test_user):
+        proj = _create_project(test_client, analyst_auth_headers)
+        resp = test_client.post(
+            f"/projects/{proj['id']}/members",
+            json={"user_id": str(test_user.id)},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 403
+
+    def test_add_nonexistent_user(self, test_client, analyst_auth_headers):
+        proj = _create_project(test_client, analyst_auth_headers)
+        fake_uid = str(uuid.uuid4())
+        resp = test_client.post(
+            f"/projects/{proj['id']}/members",
+            json={"user_id": fake_uid},
+            headers=analyst_auth_headers,
+        )
+        assert resp.status_code == 400
+
+    def test_add_existing_user_as_owner(self, test_client, analyst_auth_headers, test_user):
+        proj = _create_project(test_client, analyst_auth_headers)
+        resp = test_client.post(
+            f"/projects/{proj['id']}/members",
+            json={"user_id": str(test_user.id)},
+            headers=analyst_auth_headers,
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert str(data["user_id"]) == str(test_user.id)
+        assert "username" in data
+        assert "added_at" in data
+
+    def test_add_same_user_twice_409(self, test_client, analyst_auth_headers, test_user):
+        proj = _create_project(test_client, analyst_auth_headers)
+        test_client.post(
+            f"/projects/{proj['id']}/members",
+            json={"user_id": str(test_user.id)},
+            headers=analyst_auth_headers,
+        )
+        resp = test_client.post(
+            f"/projects/{proj['id']}/members",
+            json={"user_id": str(test_user.id)},
+            headers=analyst_auth_headers,
+        )
+        assert resp.status_code == 409
+
+    def test_admin_can_add_member(self, test_client, analyst_auth_headers, admin_auth_headers, test_user):
+        proj = _create_project(test_client, analyst_auth_headers)
+        resp = test_client.post(
+            f"/projects/{proj['id']}/members",
+            json={"user_id": str(test_user.id)},
+            headers=admin_auth_headers,
+        )
+        assert resp.status_code == 201
+
+
+# ===========================================================================
+# REMOVE MEMBER
+# ===========================================================================
+
+class TestRemoveMember:
+    def test_remove_as_owner(self, test_client, analyst_auth_headers, test_user):
+        proj = _create_project(test_client, analyst_auth_headers)
+        # Add member first
+        test_client.post(
+            f"/projects/{proj['id']}/members",
+            json={"user_id": str(test_user.id)},
+            headers=analyst_auth_headers,
+        )
+        resp = test_client.delete(
+            f"/projects/{proj['id']}/members/{test_user.id}",
+            headers=analyst_auth_headers,
+        )
+        assert resp.status_code == 204
+
+    def test_remove_non_owner_forbidden(self, test_client, analyst_auth_headers, auth_headers, test_user):
+        proj = _create_project(test_client, analyst_auth_headers)
+        test_client.post(
+            f"/projects/{proj['id']}/members",
+            json={"user_id": str(test_user.id)},
+            headers=analyst_auth_headers,
+        )
+        resp = test_client.delete(
+            f"/projects/{proj['id']}/members/{test_user.id}",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 403
+
+    def test_remove_nonexistent_returns_404(self, test_client, analyst_auth_headers, test_user):
+        proj = _create_project(test_client, analyst_auth_headers)
+        fake_uid = str(uuid.uuid4())
+        resp = test_client.delete(
+            f"/projects/{proj['id']}/members/{fake_uid}",
+            headers=analyst_auth_headers,
+        )
+        assert resp.status_code == 404
+
+    def test_admin_can_remove_member(self, test_client, analyst_auth_headers, admin_auth_headers, test_user):
+        proj = _create_project(test_client, analyst_auth_headers)
+        test_client.post(
+            f"/projects/{proj['id']}/members",
+            json={"user_id": str(test_user.id)},
+            headers=analyst_auth_headers,
+        )
+        resp = test_client.delete(
+            f"/projects/{proj['id']}/members/{test_user.id}",
+            headers=admin_auth_headers,
+        )
+        assert resp.status_code == 204
+
+    def test_member_count_updates(self, test_client, analyst_auth_headers, auth_headers, test_user):
+        proj = _create_project(test_client, analyst_auth_headers)
+        pid = proj["id"]
+
+        # Add
+        test_client.post(
+            f"/projects/{pid}/members",
+            json={"user_id": str(test_user.id)},
+            headers=analyst_auth_headers,
+        )
+        resp = test_client.get(f"/projects/{pid}", headers=auth_headers)
+        assert resp.json()["member_count"] == 1
+
+        # Remove
+        test_client.delete(f"/projects/{pid}/members/{test_user.id}", headers=analyst_auth_headers)
+        resp2 = test_client.get(f"/projects/{pid}", headers=auth_headers)
+        assert resp2.json()["member_count"] == 0

--- a/api/tests/test_projects_endpoints.py
+++ b/api/tests/test_projects_endpoints.py
@@ -1,0 +1,180 @@
+"""
+Tests for project CRUD endpoints
+"""
+import pytest
+import uuid
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _create_project(client, headers, name="TestProject", description=None):
+    payload = {"name": name}
+    if description:
+        payload["description"] = description
+    return client.post("/projects", json=payload, headers=headers)
+
+
+# ===========================================================================
+# LIST PROJECTS
+# ===========================================================================
+
+class TestListProjects:
+    def test_list_requires_auth(self, test_client):
+        resp = test_client.get("/projects")
+        assert resp.status_code == 401
+
+    def test_list_returns_empty_initially(self, test_client, auth_headers):
+        resp = test_client.get("/projects", headers=auth_headers)
+        assert resp.status_code == 200
+        assert isinstance(resp.json(), list)
+
+    def test_list_returns_created_projects(self, test_client, analyst_auth_headers, auth_headers):
+        _create_project(test_client, analyst_auth_headers, name=f"P-{uuid.uuid4().hex[:8]}")
+        resp = test_client.get("/projects", headers=auth_headers)
+        assert resp.status_code == 200
+        assert len(resp.json()) >= 1
+
+
+# ===========================================================================
+# CREATE PROJECT
+# ===========================================================================
+
+class TestCreateProject:
+    def test_create_requires_auth(self, test_client):
+        resp = test_client.post("/projects", json={"name": "X"})
+        assert resp.status_code == 401
+
+    def test_create_requires_analyst(self, test_client, auth_headers):
+        """Regular (viewer) user should not be able to create"""
+        resp = _create_project(test_client, auth_headers, name="ShouldFail")
+        # viewer role → 403
+        assert resp.status_code == 403
+
+    def test_create_as_analyst(self, test_client, analyst_auth_headers):
+        name = f"Proj-{uuid.uuid4().hex[:8]}"
+        resp = _create_project(test_client, analyst_auth_headers, name=name)
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["name"] == name
+        assert "id" in data
+        assert "created_at" in data
+
+    def test_create_with_description(self, test_client, analyst_auth_headers):
+        resp = _create_project(test_client, analyst_auth_headers, name=f"PD-{uuid.uuid4().hex[:6]}", description="My desc")
+        assert resp.status_code == 201
+        assert resp.json()["description"] == "My desc"
+
+    def test_create_empty_name_rejected(self, test_client, analyst_auth_headers):
+        resp = test_client.post("/projects", json={"name": "   "}, headers=analyst_auth_headers)
+        assert resp.status_code == 400
+
+    def test_create_as_admin(self, test_client, admin_auth_headers):
+        resp = _create_project(test_client, admin_auth_headers, name=f"Admin-{uuid.uuid4().hex[:6]}")
+        assert resp.status_code == 201
+
+
+# ===========================================================================
+# GET PROJECT
+# ===========================================================================
+
+class TestGetProject:
+    def test_get_requires_auth(self, test_client, analyst_auth_headers):
+        resp = _create_project(test_client, analyst_auth_headers, name=f"G-{uuid.uuid4().hex[:6]}")
+        pid = resp.json()["id"]
+        resp2 = test_client.get(f"/projects/{pid}")
+        assert resp2.status_code == 401
+
+    def test_get_existing(self, test_client, analyst_auth_headers, auth_headers):
+        name = f"GetMe-{uuid.uuid4().hex[:6]}"
+        resp = _create_project(test_client, analyst_auth_headers, name=name)
+        pid = resp.json()["id"]
+        resp2 = test_client.get(f"/projects/{pid}", headers=auth_headers)
+        assert resp2.status_code == 200
+        assert resp2.json()["name"] == name
+
+    def test_get_nonexistent_returns_404(self, test_client, auth_headers):
+        fake_id = str(uuid.uuid4())
+        resp = test_client.get(f"/projects/{fake_id}", headers=auth_headers)
+        assert resp.status_code == 404
+
+    def test_get_returns_counts(self, test_client, analyst_auth_headers, auth_headers):
+        resp = _create_project(test_client, analyst_auth_headers, name=f"Cnt-{uuid.uuid4().hex[:6]}")
+        pid = resp.json()["id"]
+        resp2 = test_client.get(f"/projects/{pid}", headers=auth_headers)
+        data = resp2.json()
+        assert "analysis_count" in data
+        assert "member_count" in data
+        assert data["analysis_count"] == 0
+        assert data["member_count"] == 0
+
+
+# ===========================================================================
+# UPDATE PROJECT
+# ===========================================================================
+
+class TestUpdateProject:
+    def test_update_as_owner(self, test_client, analyst_auth_headers):
+        resp = _create_project(test_client, analyst_auth_headers, name=f"OldName-{uuid.uuid4().hex[:6]}")
+        pid = resp.json()["id"]
+        resp2 = test_client.put(f"/projects/{pid}", json={"name": "NewName"}, headers=analyst_auth_headers)
+        assert resp2.status_code == 200
+        assert resp2.json()["name"] == "NewName"
+
+    def test_update_as_non_owner_forbidden(self, test_client, analyst_auth_headers, auth_headers):
+        resp = _create_project(test_client, analyst_auth_headers, name=f"Own-{uuid.uuid4().hex[:6]}")
+        pid = resp.json()["id"]
+        resp2 = test_client.put(f"/projects/{pid}", json={"name": "Hacked"}, headers=auth_headers)
+        assert resp2.status_code == 403
+
+    def test_update_as_admin(self, test_client, analyst_auth_headers, admin_auth_headers):
+        resp = _create_project(test_client, analyst_auth_headers, name=f"ForAdmin-{uuid.uuid4().hex[:6]}")
+        pid = resp.json()["id"]
+        resp2 = test_client.put(f"/projects/{pid}", json={"name": "AdminUpdated"}, headers=admin_auth_headers)
+        assert resp2.status_code == 200
+
+    def test_update_nonexistent_returns_404(self, test_client, analyst_auth_headers):
+        fake_id = str(uuid.uuid4())
+        resp = test_client.put(f"/projects/{fake_id}", json={"name": "X"}, headers=analyst_auth_headers)
+        assert resp.status_code == 404
+
+
+# ===========================================================================
+# DELETE PROJECT
+# ===========================================================================
+
+class TestDeleteProject:
+    def test_delete_as_owner(self, test_client, analyst_auth_headers):
+        resp = _create_project(test_client, analyst_auth_headers, name=f"Del-{uuid.uuid4().hex[:6]}")
+        pid = resp.json()["id"]
+        resp2 = test_client.delete(f"/projects/{pid}", headers=analyst_auth_headers)
+        assert resp2.status_code == 204
+
+    def test_delete_as_non_owner_forbidden(self, test_client, analyst_auth_headers, auth_headers):
+        resp = _create_project(test_client, analyst_auth_headers, name=f"NDel-{uuid.uuid4().hex[:6]}")
+        pid = resp.json()["id"]
+        resp2 = test_client.delete(f"/projects/{pid}", headers=auth_headers)
+        assert resp2.status_code == 403
+
+    def test_delete_as_admin(self, test_client, analyst_auth_headers, admin_auth_headers):
+        resp = _create_project(test_client, analyst_auth_headers, name=f"ADel-{uuid.uuid4().hex[:6]}")
+        pid = resp.json()["id"]
+        resp2 = test_client.delete(f"/projects/{pid}", headers=admin_auth_headers)
+        assert resp2.status_code == 204
+
+    def test_delete_nonexistent_returns_404(self, test_client, analyst_auth_headers):
+        fake_id = str(uuid.uuid4())
+        resp = test_client.delete(f"/projects/{fake_id}", headers=analyst_auth_headers)
+        assert resp.status_code == 404
+
+    def test_after_delete_get_returns_404(self, test_client, analyst_auth_headers, auth_headers):
+        resp = _create_project(test_client, analyst_auth_headers, name=f"Gone-{uuid.uuid4().hex[:6]}")
+        pid = resp.json()["id"]
+        test_client.delete(f"/projects/{pid}", headers=analyst_auth_headers)
+        resp2 = test_client.get(f"/projects/{pid}", headers=auth_headers)
+        assert resp2.status_code == 404

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "react-icons": "^5.5.0",
     "react-router-dom": "^6.26.1",
     "react-scripts": "^5.0.1",
+    "react-select": "^5.8.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -33,6 +33,7 @@ import Reports from './components/Reports';
 import CreateInformationSystem from './components/CreateInformationSystem';
 import UploadDiagram from './components/UploadDiagram';
 import UserManagement from './components/UserManagement';
+import ProjectManager from './components/ProjectManager';
 
 // Componente AppContent - Contenido principal de la aplicación
 function AppContent() {
@@ -135,6 +136,15 @@ function AppContent() {
             element={
               <ProtectedRoute>
                 <UserManagement />
+              </ProtectedRoute>
+            }
+          />
+
+          <Route
+            path="/projects"
+            element={
+              <ProtectedRoute>
+                <ProjectManager />
               </ProtectedRoute>
             }
           />

--- a/frontend/src/components/Analysis.jsx
+++ b/frontend/src/components/Analysis.jsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { FaTrash, FaFilePdf, FaEdit, FaEye, FaTable, FaThLarge, FaEyeSlash } from "react-icons/fa";
 import { Flex, TableContainer, Table, Tr, Td, Thead, Th, Tbody, Card, CardHeader, CardBody, Grid, GridItem, Text, Image as ChakraImage, Modal, ModalOverlay, ModalContent, ModalCloseButton, ModalBody, useDisclosure, Button, useToast, Tabs, TabList, TabPanels, Tab, TabPanel, Accordion, AccordionItem, AccordionButton, AccordionPanel, AccordionIcon, VStack, HStack, Divider, Badge, useColorModeValue, Box, Tooltip, Switch, FormControl, FormLabel } from "@chakra-ui/react";
-import { fetchInformationSystemById, getInformationSystemById, updateThreatsRiskBatch, createThreatForSystem, deleteThreat } from "../services/index";
+import { fetchInformationSystemById, getInformationSystemById, updateThreatsRiskBatch, createThreatForSystem, deleteThreat, updateInformationSystem } from "../services/index";
 import { useLocalization, getOwaspSelectOptions } from '../hooks/useLocalization';
 import { useAuth } from '../context/AuthContext';
 import OwaspSelector from './OwaspSelector';
@@ -11,6 +11,7 @@ import ReportGenerator from './ReportGenerator';
 import RiskDisplay from './RiskDisplay';
 import ResidualRiskSelector from './ResidualRiskSelector';
 import ControlTagsWithAutocomplete from './ControlTagsWithAutocomplete';
+import ProjectCombobox from './ProjectCombobox';
 import { calculateInherentRisk, getRiskColorCSS, getRiskLabel } from '../utils/riskCalculations';
 import { handleTextareaResize, calculateTextareaHeight } from '../utils/textareaHelpers';
 
@@ -98,6 +99,8 @@ const Analysis = () => {
   // States to control table view
   const [viewMode, setViewMode] = useState('compact'); // 'compact', 'detailed', 'tabs'
   const [showRiskAssessment, setShowRiskAssessment] = useState(true); // Controls OWASP evaluation visibility
+  const [projectValue, setProjectValue] = useState(null);
+  const [isSavingProject, setIsSavingProject] = useState(false);
 
   // Generic function to get risk values formatted to 1 decimal
   const getRiskValue = (threatId, riskType = 'inherent') => {
@@ -383,6 +386,13 @@ const Analysis = () => {
     setServiceData(data);
     setThreats(data?.threats || []);
 
+    // Sync project state
+    if (data?.project_id) {
+      setProjectValue({ id: data.project_id, name: data.project_name || '', isNew: false });
+    } else {
+      setProjectValue(null);
+    }
+
     if (data?.diagram_input_type === "text" && data?.diagram) {
       try {
         const res = await fetch(`/diagrams/${data.diagram}`);
@@ -571,6 +581,62 @@ const Analysis = () => {
               <Text fontSize="md" color="gray.700" lineHeight="1.5">
                 {serviceData.description}
               </Text>
+            </GridItem>
+
+            <GridItem>
+              <Text fontWeight="bold" color="blue.600" fontSize="md">
+                {t?.projects?.project || 'Project'}:
+              </Text>
+            </GridItem>
+            <GridItem>
+              <HStack spacing={2} align="center">
+                <Box flex="1" maxWidth="340px">
+                  <ProjectCombobox
+                    value={projectValue}
+                    onChange={setProjectValue}
+                    isDisabled={!canWrite}
+                  />
+                </Box>
+                {canWrite && (
+                  <Button
+                    size="sm"
+                    colorScheme="teal"
+                    isLoading={isSavingProject}
+                    onClick={async () => {
+                      setIsSavingProject(true);
+                      try {
+                        const payload = {};
+                        if (projectValue) {
+                          if (projectValue.isNew) {
+                            // Project by name not supported from here — requires backend create-inline
+                            // Create via project name passed as special field
+                            payload.project_name_inline = projectValue.name;
+                          } else {
+                            payload.project_id = projectValue.id;
+                          }
+                        } else {
+                          payload.project_id = null;
+                        }
+                        await updateInformationSystem(id, payload);
+                        const freshData = await fetchInformationSystemById(id);
+                        setServiceData(freshData);
+                        if (freshData?.project_id) {
+                          setProjectValue({ id: freshData.project_id, name: freshData.project_name || '', isNew: false });
+                        } else {
+                          setProjectValue(null);
+                        }
+                        showNotification(t?.projects?.updated || 'Updated', t?.projects?.project || 'Project assignment saved', 'success');
+                      } catch {
+                        showNotification('Error', 'Could not update project', 'error');
+                      } finally {
+                        setIsSavingProject(false);
+                      }
+                    }}
+                  >
+                    {t?.ui?.save || 'Save'}
+                  </Button>
+                )}
+              </HStack>
             </GridItem>
           </Grid>
           

--- a/frontend/src/components/CreateInformationSystem.jsx
+++ b/frontend/src/components/CreateInformationSystem.jsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Flex, Box, Input, Button, Textarea, Heading, useToast, Alert, AlertIcon } from "@chakra-ui/react";
+import { Flex, Box, Input, Button, Textarea, Heading, useToast, Alert, AlertIcon, FormLabel } from "@chakra-ui/react";
 import { createInformationSystem } from "../services";
 import { useLocalization } from '../hooks/useLocalization';
 import { useAuth } from '../context/AuthContext';
+import ProjectCombobox from './ProjectCombobox';
 
 const CreateInformationSystem = () => {
   const { t } = useLocalization();
@@ -11,14 +12,20 @@ const CreateInformationSystem = () => {
   const toast = useToast();
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
-  const [diagram, setDiagram] = useState(null);
+  const [project, setProject] = useState(null);
   const navigate = useNavigate();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      // Enviar solo los datos, sin imagen
       const data = { title, description };
+      if (project) {
+        if (project.isNew) {
+          data.project_name = project.name;
+        } else {
+          data.project_id = project.id;
+        }
+      }
       const res = await createInformationSystem(data);
       const id = res.data.id;
       
@@ -32,7 +39,7 @@ const CreateInformationSystem = () => {
         variant: 'left-accent'
       });
       
-      navigate(`/upload/${id}`); // Redirige a la subida de imagen
+      navigate(`/upload/${id}`);
     } catch (error) {
       toast({
         title: t?.ui?.form?.error_creating_title || "Error",
@@ -73,6 +80,14 @@ const CreateInformationSystem = () => {
             required
             isDisabled={!canWrite}
           />
+          <FormLabel fontSize="sm" mb={1}>{t?.projects?.project || 'Project'}</FormLabel>
+          <Box mb={4}>
+            <ProjectCombobox
+              value={project}
+              onChange={setProject}
+              isDisabled={!canWrite}
+            />
+          </Box>
           {canWrite && (
             <Button type="submit" colorScheme="teal" width="full">{t.ui.form.create_button}</Button>
           )}

--- a/frontend/src/components/Index.jsx
+++ b/frontend/src/components/Index.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import {getInformationSystems} from "../services";
+import { getProjects } from "../services/projectService";
 import { 
   Flex, 
   TableContainer, 
@@ -15,7 +16,8 @@ import {
   Text,
   Box,
   Select,
-  Spinner
+  Spinner,
+  Badge
 } from "@chakra-ui/react";
 import { ChevronLeftIcon, ChevronRightIcon } from '@chakra-ui/icons';
 import { useLocalization } from '../hooks/useLocalization';
@@ -28,41 +30,33 @@ const Index = () => {
   const [totalSystems, setTotalSystems] = useState(0);
   const [pageSize, setPageSize] = useState(10);
   const [totalPages, setTotalPages] = useState(1);
+  const [projects, setProjects] = useState([]);
+  const [selectedProjectId, setSelectedProjectId] = useState('');
 
-  const fetchData = async (page, size) => {
+  useEffect(() => {
+    getProjects().then((res) => setProjects(res.data)).catch(() => {});
+  }, []);
+
+  const fetchData = async (page, size, projectId) => {
     setIsLoading(true);
     try {
       const skip = (page - 1) * size;
-      const res = await getInformationSystems(skip, size);
+      const res = await getInformationSystems(skip, size, projectId || null);
       setServiceData(res.data);
       
-      // Actualizamos el total de sistemas usando el contador real de la API
       if (res.totalCount !== undefined) {
         setTotalSystems(res.totalCount);
-        console.log(`Total de sistemas obtenido de la API: ${res.totalCount}`);
-      }
-      // Como respaldo, estimamos el total basado en los datos recibidos
-      else if (res.data.length > 0) {
-        // Si estamos en la última página y hay menos registros que el tamaño de página
+      } else if (res.data.length > 0) {
         if (page > 1 && res.data.length < size) {
-          const newTotal = (page - 1) * size + res.data.length;
-          setTotalSystems(newTotal);
-          console.log(`Estimando total de sistemas: ${newTotal} (página incompleta)`);
+          setTotalSystems((page - 1) * size + res.data.length);
         } else if (page === 1 && res.data.length < size) {
           setTotalSystems(res.data.length);
-          console.log(`Estimando total de sistemas: ${res.data.length} (primera página)`);
         } else {
-          // En caso contrario, aumentamos el contador en cada llamada
-          const newTotal = Math.max(totalSystems, page * size + 1); // +1 para asegurar que haya otra página
-          setTotalSystems(newTotal);
-          console.log(`Estimando total de sistemas: ${newTotal} (página completa)`);
+          setTotalSystems(Math.max(totalSystems, page * size + 1));
         }
       } else {
-        // Si no hay datos, el total es 0
         setTotalSystems(0);
-        console.log('No hay sistemas disponibles');
       }
-      
     } catch (error) {
       console.error("Error al cargar los sistemas:", error);
     } finally {
@@ -70,32 +64,29 @@ const Index = () => {
     }
   };
 
-  // Calculamos el número total de páginas cuando cambia totalSystems o pageSize
   useEffect(() => {
     const calculatedPages = Math.max(1, Math.ceil(totalSystems / pageSize));
     setTotalPages(calculatedPages);
-    console.log(`Recalculando totalPages: ${calculatedPages} (totalSystems: ${totalSystems}, pageSize: ${pageSize})`);
   }, [totalSystems, pageSize]);
 
-  // Cargamos datos iniciales y cuando cambia la paginación
   useEffect(() => {
-    fetchData(currentPage, pageSize);
-  }, [currentPage, pageSize]);
+    fetchData(currentPage, pageSize, selectedProjectId);
+  }, [currentPage, pageSize, selectedProjectId]);
 
   const handlePageChange = (newPage) => {
-    // Asegurarse de que la página esté en el rango válido
     if (newPage >= 1 && newPage <= totalPages) {
-      console.log(`Cambiando a página ${newPage} de ${totalPages}`);
       setCurrentPage(newPage);
-    } else {
-      console.log(`Intento de cambiar a página inválida: ${newPage} (totalPages: ${totalPages})`);
     }
   };
 
   const handlePageSizeChange = (event) => {
-    const newSize = parseInt(event.target.value);
-    setPageSize(newSize);
-    setCurrentPage(1); // Volver a la primera página al cambiar el tamaño
+    setPageSize(parseInt(event.target.value));
+    setCurrentPage(1);
+  };
+
+  const handleProjectFilterChange = (event) => {
+    setSelectedProjectId(event.target.value);
+    setCurrentPage(1);
   };
 
   if (isLoading && serviceData.length === 0) {
@@ -116,19 +107,38 @@ const Index = () => {
       style={{ marginBottom: "60px" }}
     >
       <Box width="100%" maxWidth="1000px">
+        {/* Project filter */}
+        <Flex mb={3} align="center" gap={2}>
+          <Text fontSize="sm" fontWeight="medium" whiteSpace="nowrap">
+            {t?.projects?.project || 'Proyecto'}:
+          </Text>
+          <Select
+            value={selectedProjectId}
+            onChange={handleProjectFilterChange}
+            size="sm"
+            maxWidth="260px"
+          >
+            <option value="">{t?.projects?.filterAll || 'Todos los proyectos'}</option>
+            {projects.map((p) => (
+              <option key={p.id} value={p.id}>{p.name}</option>
+            ))}
+          </Select>
+        </Flex>
+
         <TableContainer>
           <Table border="2px solid gray" borderCollapse="collapse" variant='striped' colorScheme='gray' overflowX='auto' whiteSpace='normal' width="100%">
             <Thead>
               <Tr bg="blue.500" color="white" p="4">
                 <Th color="white" p="3" shadow="md">{t?.ui?.table?.title || 'Título'}</Th>
                 <Th color="white" p="3" shadow="md">{t?.ui?.table?.description || 'Descripción'}</Th>
+                <Th color="white" p="3" shadow="md">{t?.projects?.project || 'Proyecto'}</Th>
                 <Th color="white" p="3" shadow="md" maxWidth='180px'>{t?.ui?.table?.date || 'Fecha'}</Th>
               </Tr>
             </Thead>
             <Tbody>
               {serviceData.length === 0 ? (
                 <Tr>
-                  <Td colSpan={3} textAlign="center" py={6}>
+                  <Td colSpan={4} textAlign="center" py={6}>
                     {t?.ui?.no_systems || 'No hay sistemas disponibles'}
                   </Td>
                 </Tr>
@@ -139,6 +149,12 @@ const Index = () => {
                     <Tr key={data.id}>
                       <Td><Link to={`analysis/${data.id}`} style={{ color: 'blue.600', fontWeight: 'medium' }}>{String(data.title)}</Link></Td>
                       <Td>{data.description}</Td>
+                      <Td>
+                        {data.project_name
+                          ? <Badge colorScheme="blue" borderRadius="md" px={2}>{data.project_name}</Badge>
+                          : <Text color="gray.400" fontSize="sm">{t?.projects?.noProject || '—'}</Text>
+                        }
+                      </Td>
                       <Td>{dateTime}</Td>
                     </Tr>
                   );
@@ -146,7 +162,7 @@ const Index = () => {
               )}
               {isLoading && (
                 <Tr>
-                  <Td colSpan={3} textAlign="center" py={4}>
+                  <Td colSpan={4} textAlign="center" py={4}>
                     <Spinner size="sm" color="blue.500" mr={2} />
                     {t?.ui?.loading_more || 'Cargando más resultados...'}
                   </Td>

--- a/frontend/src/components/Navigation.jsx
+++ b/frontend/src/components/Navigation.jsx
@@ -34,12 +34,13 @@ const NavLink = ({ to, children, exact }) => {
 
 const Navigation = () => {
   const { t } = useLocalization();
-  const { isAdmin } = useAuth();
+  const { isAdmin, canWrite } = useAuth();
 
   return (
     <Flex {...navBarStyle}>
       <NavLink to="/create">{t.ui.menu.new_analysis}</NavLink>
       <NavLink to="/" exact>{t.ui.menu.archive}</NavLink>
+      {canWrite && <NavLink to="/projects">{t?.projects?.title || 'Proyectos'}</NavLink>}
       <NavLink to="/reports">{t.ui.menu.reports}</NavLink>
       {isAdmin && <NavLink to="/users">{t.ui.menu.users}</NavLink>}
     </Flex>

--- a/frontend/src/components/ProjectCombobox.jsx
+++ b/frontend/src/components/ProjectCombobox.jsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react';
+import CreatableSelect from 'react-select/creatable';
+import { getProjects } from '../services';
+import { useLocalization } from '../hooks/useLocalization';
+
+const ProjectCombobox = ({ value, onChange, isDisabled = false }) => {
+  const { t } = useLocalization();
+  const [options, setOptions] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    getProjects()
+      .then((res) => {
+        if (!cancelled) {
+          const opts = res.data.map((p) => ({ value: p.id, label: p.name }));
+          setOptions(opts);
+        }
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  const handleChange = (selected) => {
+    if (!selected) {
+      onChange(null);
+    } else if (selected.__isNew__) {
+      onChange({ id: null, name: selected.value, isNew: true });
+    } else {
+      onChange({ id: selected.value, name: selected.label, isNew: false });
+    }
+  };
+
+  const formatCreateLabel = (inputValue) => {
+    const template = t?.projects?.createNew || 'Create "{{name}}"';
+    return template.replace('{{name}}', inputValue);
+  };
+
+  const currentValue = value
+    ? value.isNew
+      ? { value: value.name, label: value.name, __isNew__: true }
+      : { value: value.id, label: value.name }
+    : null;
+
+  return (
+    <CreatableSelect
+      isClearable
+      isDisabled={isDisabled}
+      isLoading={isLoading}
+      options={options}
+      value={currentValue}
+      onChange={handleChange}
+      formatCreateLabel={formatCreateLabel}
+      placeholder={t?.projects?.namePlaceholder || 'Select or create project...'}
+      noOptionsMessage={() => t?.projects?.namePlaceholder || 'Type to search...'}
+      styles={{
+        container: (base) => ({ ...base, width: '100%' }),
+        control: (base) => ({
+          ...base,
+          borderColor: '#CBD5E0',
+          borderRadius: '6px',
+          minHeight: '40px',
+          boxShadow: 'none',
+          '&:hover': { borderColor: '#A0AEC0' },
+        }),
+      }}
+    />
+  );
+};
+
+export default ProjectCombobox;

--- a/frontend/src/components/ProjectManager.jsx
+++ b/frontend/src/components/ProjectManager.jsx
@@ -1,0 +1,296 @@
+import { useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Flex,
+  Heading,
+  IconButton,
+  Input,
+  Spinner,
+  Table,
+  Tbody,
+  Td,
+  Text,
+  Th,
+  Thead,
+  Tr,
+  useToast,
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogContent,
+  AlertDialogOverlay,
+  useDisclosure,
+  Badge,
+  Textarea,
+  HStack,
+} from '@chakra-ui/react';
+import { DeleteIcon, EditIcon, ChevronDownIcon, ChevronRightIcon } from '@chakra-ui/icons';
+import { useRef } from 'react';
+import {
+  getProjects,
+  createProject,
+  updateProject,
+  deleteProject,
+} from '../services/projectService';
+import { useLocalization } from '../hooks/useLocalization';
+import { useAuth } from '../context/AuthContext';
+import ProjectMembersManager from './ProjectMembersManager';
+
+const ProjectManager = () => {
+  const { t } = useLocalization();
+  const { isAdmin, canWrite, user } = useAuth();
+  const toast = useToast();
+
+  const [projects, setProjects] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [expandedId, setExpandedId] = useState(null);
+
+  // New project form
+  const [newName, setNewName] = useState('');
+  const [newDesc, setNewDesc] = useState('');
+  const [isCreating, setIsCreating] = useState(false);
+
+  // Edit state
+  const [editingId, setEditingId] = useState(null);
+  const [editName, setEditName] = useState('');
+  const [editDesc, setEditDesc] = useState('');
+
+  // Delete confirmation
+  const { isOpen: isDeleteOpen, onOpen: onDeleteOpen, onClose: onDeleteClose } = useDisclosure();
+  const [deletingProject, setDeletingProject] = useState(null);
+  const cancelRef = useRef();
+
+  const loadProjects = async () => {
+    setIsLoading(true);
+    try {
+      const res = await getProjects();
+      setProjects(res.data);
+    } catch {
+      toast({ title: 'Error', description: 'No se pudo cargar los proyectos', status: 'error', duration: 3000 });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => { loadProjects(); }, []);
+
+  const handleCreate = async (e) => {
+    e.preventDefault();
+    if (!newName.trim()) return;
+    setIsCreating(true);
+    try {
+      await createProject({ name: newName.trim(), description: newDesc.trim() || null });
+      setNewName('');
+      setNewDesc('');
+      toast({ title: t?.projects?.created || 'Proyecto creado', status: 'success', duration: 2000 });
+      loadProjects();
+    } catch (err) {
+      toast({ title: 'Error', description: err?.response?.data?.detail || 'No se pudo crear', status: 'error', duration: 3000 });
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const startEdit = (p) => {
+    setEditingId(p.id);
+    setEditName(p.name);
+    setEditDesc(p.description || '');
+  };
+
+  const handleUpdate = async (projectId) => {
+    try {
+      await updateProject(projectId, { name: editName.trim(), description: editDesc.trim() || null });
+      setEditingId(null);
+      toast({ title: t?.projects?.updated || 'Proyecto actualizado', status: 'success', duration: 2000 });
+      loadProjects();
+    } catch (err) {
+      toast({ title: 'Error', description: err?.response?.data?.detail || 'No se pudo actualizar', status: 'error', duration: 3000 });
+    }
+  };
+
+  const confirmDelete = (p) => {
+    setDeletingProject(p);
+    onDeleteOpen();
+  };
+
+  const handleDelete = async () => {
+    if (!deletingProject) return;
+    try {
+      await deleteProject(deletingProject.id);
+      toast({ title: t?.projects?.deleted || 'Proyecto eliminado', status: 'info', duration: 2000 });
+      onDeleteClose();
+      loadProjects();
+    } catch (err) {
+      toast({ title: 'Error', description: err?.response?.data?.detail || 'No se pudo eliminar', status: 'error', duration: 3000 });
+    }
+  };
+
+  const canManage = (project) =>
+    isAdmin || (user && String(project.created_by) === String(user.id));
+
+  if (isLoading) {
+    return (
+      <Flex align="center" justify="center" mt={10}>
+        <Spinner size="xl" color="blue.500" />
+      </Flex>
+    );
+  }
+
+  return (
+    <Box maxWidth="900px" mx="auto" mt={6} px={4}>
+      <Heading size="md" mb={4}>{t?.projects?.title || 'Proyectos'}</Heading>
+
+      {/* Create form */}
+      {canWrite && (
+        <Box as="form" onSubmit={handleCreate} mb={6} p={4} borderWidth={1} borderRadius={8} bg="gray.50">
+          <Heading size="sm" mb={3}>{t?.projects?.created ? 'Nuevo proyecto' : 'New project'}</Heading>
+          <HStack mb={2}>
+            <Input
+              placeholder={t?.projects?.namePlaceholder || 'Nombre del proyecto'}
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              required
+              size="sm"
+            />
+          </HStack>
+          <Textarea
+            placeholder={t?.projects?.description || 'Descripción (opcional)'}
+            value={newDesc}
+            onChange={(e) => setNewDesc(e.target.value)}
+            size="sm"
+            mb={2}
+            rows={2}
+          />
+          <Button type="submit" colorScheme="teal" size="sm" isLoading={isCreating}>
+            {t?.projects?.created || 'Crear proyecto'}
+          </Button>
+        </Box>
+      )}
+
+      {/* Projects table */}
+      {projects.length === 0 ? (
+        <Text color="gray.500">{t?.projects?.noProject || 'No hay proyectos'}</Text>
+      ) : (
+        <Table variant="simple" size="sm">
+          <Thead bg="blue.500">
+            <Tr>
+              <Th color="white" w="8"></Th>
+              <Th color="white">{t?.projects?.title || 'Proyecto'}</Th>
+              <Th color="white">{t?.projects?.description || 'Descripción'}</Th>
+              <Th color="white" isNumeric>{t?.projects?.analyses || 'Análisis'}</Th>
+              <Th color="white" isNumeric>{t?.projects?.members || 'Miembros'}</Th>
+              <Th color="white" w="28"></Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {projects.map((p) => (
+              <>
+                <Tr key={p.id} _hover={{ bg: 'gray.50' }}>
+                  <Td>
+                    <IconButton
+                      icon={expandedId === p.id ? <ChevronDownIcon /> : <ChevronRightIcon />}
+                      size="xs"
+                      variant="ghost"
+                      aria-label="toggle members"
+                      onClick={() => setExpandedId(expandedId === p.id ? null : p.id)}
+                    />
+                  </Td>
+                  <Td>
+                    {editingId === p.id ? (
+                      <Input
+                        size="xs"
+                        value={editName}
+                        onChange={(e) => setEditName(e.target.value)}
+                        autoFocus
+                      />
+                    ) : (
+                      <Text fontWeight="medium">{p.name}</Text>
+                    )}
+                  </Td>
+                  <Td>
+                    {editingId === p.id ? (
+                      <Input
+                        size="xs"
+                        value={editDesc}
+                        onChange={(e) => setEditDesc(e.target.value)}
+                      />
+                    ) : (
+                      <Text color="gray.600" fontSize="sm" noOfLines={1}>{p.description || '—'}</Text>
+                    )}
+                  </Td>
+                  <Td isNumeric>
+                    <Badge colorScheme="blue">{p.analysis_count}</Badge>
+                  </Td>
+                  <Td isNumeric>
+                    <Badge colorScheme="green">{p.member_count}</Badge>
+                  </Td>
+                  <Td>
+                    {canManage(p) && (
+                      <HStack spacing={1} justify="flex-end">
+                        {editingId === p.id ? (
+                          <>
+                            <Button size="xs" colorScheme="teal" onClick={() => handleUpdate(p.id)}>✓</Button>
+                            <Button size="xs" onClick={() => setEditingId(null)}>✕</Button>
+                          </>
+                        ) : (
+                          <>
+                            <IconButton
+                              icon={<EditIcon />}
+                              size="xs"
+                              variant="ghost"
+                              colorScheme="blue"
+                              aria-label="edit"
+                              onClick={() => startEdit(p)}
+                            />
+                            <IconButton
+                              icon={<DeleteIcon />}
+                              size="xs"
+                              variant="ghost"
+                              colorScheme="red"
+                              aria-label="delete"
+                              onClick={() => confirmDelete(p)}
+                            />
+                          </>
+                        )}
+                      </HStack>
+                    )}
+                  </Td>
+                </Tr>
+                {expandedId === p.id && (
+                  <Tr key={`members-${p.id}`}>
+                    <Td colSpan={6} bg="gray.50" p={4}>
+                      <ProjectMembersManager project={p} canManage={canManage(p)} />
+                    </Td>
+                  </Tr>
+                )}
+              </>
+            ))}
+          </Tbody>
+        </Table>
+      )}
+
+      {/* Delete confirmation dialog */}
+      <AlertDialog isOpen={isDeleteOpen} leastDestructiveRef={cancelRef} onClose={onDeleteClose}>
+        <AlertDialogOverlay>
+          <AlertDialogContent>
+            <AlertDialogHeader>{t?.projects?.deleteConfirm || '¿Eliminar proyecto?'}</AlertDialogHeader>
+            <AlertDialogBody>
+              <Text><strong>{deletingProject?.name}</strong></Text>
+              <Text mt={2} fontSize="sm" color="gray.600">
+                Las análisis asignadas a este proyecto quedarán sin proyecto asignado.
+              </Text>
+            </AlertDialogBody>
+            <AlertDialogFooter>
+              <Button ref={cancelRef} onClick={onDeleteClose}>Cancelar</Button>
+              <Button colorScheme="red" onClick={handleDelete} ml={3}>Eliminar</Button>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialogOverlay>
+      </AlertDialog>
+    </Box>
+  );
+};
+
+export default ProjectManager;

--- a/frontend/src/components/ProjectMembersManager.jsx
+++ b/frontend/src/components/ProjectMembersManager.jsx
@@ -1,0 +1,154 @@
+import { useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Flex,
+  HStack,
+  IconButton,
+  Input,
+  Spinner,
+  Table,
+  Tbody,
+  Td,
+  Text,
+  Th,
+  Thead,
+  Tr,
+  useToast,
+  Badge,
+} from '@chakra-ui/react';
+import { DeleteIcon } from '@chakra-ui/icons';
+import { getProjectMembers, addProjectMember, removeProjectMember } from '../services/projectService';
+import { useLocalization } from '../hooks/useLocalization';
+
+const ProjectMembersManager = ({ project, canManage }) => {
+  const { t } = useLocalization();
+  const toast = useToast();
+
+  const [members, setMembers] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [newUserId, setNewUserId] = useState('');
+  const [isAdding, setIsAdding] = useState(false);
+
+  const load = async () => {
+    setIsLoading(true);
+    try {
+      const res = await getProjectMembers(project.id);
+      setMembers(res.data);
+    } catch {
+      setMembers([]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => { load(); }, [project.id]);
+
+  const handleAdd = async (e) => {
+    e.preventDefault();
+    if (!newUserId.trim()) return;
+    setIsAdding(true);
+    try {
+      await addProjectMember(project.id, { user_id: newUserId.trim() });
+      setNewUserId('');
+      toast({ title: t?.projects?.addMember || 'Miembro agregado', status: 'success', duration: 2000 });
+      load();
+    } catch (err) {
+      toast({
+        title: 'Error',
+        description: err?.response?.data?.detail || 'No se pudo agregar el miembro',
+        status: 'error',
+        duration: 3000,
+      });
+    } finally {
+      setIsAdding(false);
+    }
+  };
+
+  const handleRemove = async (userId) => {
+    try {
+      await removeProjectMember(project.id, userId);
+      toast({ title: t?.projects?.removeMember || 'Miembro eliminado', status: 'info', duration: 2000 });
+      load();
+    } catch (err) {
+      toast({
+        title: 'Error',
+        description: err?.response?.data?.detail || 'No se pudo eliminar',
+        status: 'error',
+        duration: 3000,
+      });
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <Flex align="center" gap={2}>
+        <Spinner size="sm" />
+        <Text fontSize="sm">Cargando miembros...</Text>
+      </Flex>
+    );
+  }
+
+  return (
+    <Box>
+      <Text fontWeight="semibold" mb={2} fontSize="sm">{t?.projects?.members || 'Miembros'}</Text>
+
+      {members.length === 0 ? (
+        <Text fontSize="sm" color="gray.500" mb={3}>No hay miembros asignados</Text>
+      ) : (
+        <Table size="xs" variant="simple" mb={3}>
+          <Thead>
+            <Tr>
+              <Th fontSize="xs">Usuario</Th>
+              <Th fontSize="xs">Nombre</Th>
+              <Th fontSize="xs">Rol</Th>
+              <Th fontSize="xs">Agregado</Th>
+              {canManage && <Th w="10"></Th>}
+            </Tr>
+          </Thead>
+          <Tbody>
+            {members.map((m) => (
+              <Tr key={m.user_id}>
+                <Td fontSize="xs">{m.username}</Td>
+                <Td fontSize="xs">{m.name}</Td>
+                <Td fontSize="xs">
+                  <Badge colorScheme={m.role === 'admin' ? 'red' : 'blue'} fontSize="2xs">{m.role}</Badge>
+                </Td>
+                <Td fontSize="xs">{new Date(m.added_at).toLocaleDateString()}</Td>
+                {canManage && (
+                  <Td>
+                    <IconButton
+                      icon={<DeleteIcon />}
+                      size="xs"
+                      variant="ghost"
+                      colorScheme="red"
+                      aria-label="remove"
+                      onClick={() => handleRemove(m.user_id)}
+                    />
+                  </Td>
+                )}
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      )}
+
+      {canManage && (
+        <HStack as="form" onSubmit={handleAdd} spacing={2}>
+          <Input
+            placeholder="UUID del usuario..."
+            value={newUserId}
+            onChange={(e) => setNewUserId(e.target.value)}
+            size="xs"
+            maxWidth="280px"
+          />
+          <Button type="submit" size="xs" colorScheme="teal" isLoading={isAdding}>
+            {t?.projects?.addMember || 'Agregar'}
+          </Button>
+        </HStack>
+      )}
+    </Box>
+  );
+};
+
+export default ProjectMembersManager;

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -348,6 +348,21 @@
           "critical": "Critical"
         }
       }
-    }
-  }
+    }  },
+  "projects": {
+    "title": "Projects",
+    "noProject": "No project",
+    "createNew": "Create \"{{name}}\"",
+    "namePlaceholder": "Select or create project...",
+    "description": "Description",
+    "members": "Members",
+    "addMember": "Add member",
+    "removeMember": "Remove member",
+    "analyses": "Analyses",
+    "deleteConfirm": "Delete this project?",
+    "deleted": "Project deleted",
+    "created": "Project created",
+    "updated": "Project updated",
+    "filterAll": "All projects",
+    "project": "Project"  }
 }

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -348,6 +348,21 @@
           "critical": "Crítico"
         }
       }
-    }
-  }
+    }  },
+  "projects": {
+    "title": "Proyectos",
+    "noProject": "Sin proyecto",
+    "createNew": "Crear \"{{name}}\"",
+    "namePlaceholder": "Seleccionar o crear proyecto...",
+    "description": "Descripción",
+    "members": "Miembros",
+    "addMember": "Agregar miembro",
+    "removeMember": "Eliminar miembro",
+    "analyses": "Análisis",
+    "deleteConfirm": "¿Eliminar este proyecto?",
+    "deleted": "Proyecto eliminado",
+    "created": "Proyecto creado",
+    "updated": "Proyecto actualizado",
+    "filterAll": "Todos los proyectos",
+    "project": "Proyecto"  }
 }

--- a/frontend/src/services/index.js
+++ b/frontend/src/services/index.js
@@ -8,6 +8,7 @@ import apiClient, { API_BASE_URL } from './apiClient';
 import * as authService from './authService';
 import * as informationSystemService from './informationSystemService';
 import * as threatService from './threatService';
+import * as projectService from './projectService';
 
 // Exportar todos los servicios
 export const { 
@@ -22,7 +23,8 @@ export const {
   createInformationSystem,
   uploadDiagram,
   uploadDiagramText,
-  fetchInformationSystemById
+  fetchInformationSystemById,
+  updateInformationSystem
 } = informationSystemService;
 
 export const {
@@ -35,6 +37,17 @@ export const {
   updateThreatRisk,
   deleteThreat
 } = threatService;
+
+export const {
+  getProjects,
+  createProject,
+  getProject,
+  updateProject,
+  deleteProject,
+  getProjectMembers,
+  addProjectMember,
+  removeProjectMember
+} = projectService;
 
 // Para mantener compatibilidad con código antiguo
 export const getInformationSystemsById = informationSystemService.getInformationSystemById;

--- a/frontend/src/services/informationSystemService.js
+++ b/frontend/src/services/informationSystemService.js
@@ -10,14 +10,15 @@ import apiClient from './apiClient';
  * @param {number} limit - Cantidad máxima de sistemas a recuperar
  * @returns {Promise} - Promise con los datos de sistemas y conteo total
  */
-export const getInformationSystems = async (skip = 0, limit = 10) => {
+export const getInformationSystems = async (skip = 0, limit = 10, project_id = null) => {
   try {
+    const projectParam = project_id ? `&project_id=${project_id}` : '';
     // Primero obtenemos el total de sistemas (sin límite)
-    const countResponse = await apiClient.get(`/information_systems?skip=0&limit=1000`);
+    const countResponse = await apiClient.get(`/information_systems?skip=0&limit=1000${projectParam}`);
     const totalCount = countResponse.data.length;
     
     // Luego obtenemos los datos paginados
-    const dataResponse = await apiClient.get(`/information_systems?skip=${skip}&limit=${limit}`);
+    const dataResponse = await apiClient.get(`/information_systems?skip=${skip}&limit=${limit}${projectParam}`);
     
     // Agregamos el conteo total a la respuesta
     dataResponse.totalCount = totalCount;
@@ -114,4 +115,20 @@ export const uploadDiagramText = async (id, text) => {
 export const fetchInformationSystemById = async (id) => {
   const res = await getInformationSystemById(id);
   return res.data;
+};
+
+/**
+ * Update an information system (title, description, or project assignment)
+ * @param {string} id - Information system UUID
+ * @param {object} data - Fields to update: { title, description, project_id }
+ * @returns {Promise} - Updated information system
+ */
+export const updateInformationSystem = async (id, data) => {
+  try {
+    const response = await apiClient.put(`/information_systems/${id}`, data);
+    return response;
+  } catch (error) {
+    console.error('Error al actualizar sistema de información:', error);
+    throw error;
+  }
 };

--- a/frontend/src/services/projectService.js
+++ b/frontend/src/services/projectService.js
@@ -1,0 +1,65 @@
+import apiClient from './apiClient';
+
+export const getProjects = async (skip = 0, limit = 100) => {
+  try {
+    return await apiClient.get(`/projects?skip=${skip}&limit=${limit}`);
+  } catch (error) {
+    throw new Error(error.response?.data?.detail || 'Error al obtener proyectos');
+  }
+};
+
+export const createProject = async (data) => {
+  try {
+    return await apiClient.post('/projects', data);
+  } catch (error) {
+    throw new Error(error.response?.data?.detail || 'Error al crear proyecto');
+  }
+};
+
+export const getProject = async (projectId) => {
+  try {
+    return await apiClient.get(`/projects/${projectId}`);
+  } catch (error) {
+    throw new Error(error.response?.data?.detail || 'Error al obtener proyecto');
+  }
+};
+
+export const updateProject = async (projectId, data) => {
+  try {
+    return await apiClient.put(`/projects/${projectId}`, data);
+  } catch (error) {
+    throw new Error(error.response?.data?.detail || 'Error al actualizar proyecto');
+  }
+};
+
+export const deleteProject = async (projectId) => {
+  try {
+    return await apiClient.delete(`/projects/${projectId}`);
+  } catch (error) {
+    throw new Error(error.response?.data?.detail || 'Error al eliminar proyecto');
+  }
+};
+
+export const getProjectMembers = async (projectId) => {
+  try {
+    return await apiClient.get(`/projects/${projectId}/members`);
+  } catch (error) {
+    throw new Error(error.response?.data?.detail || 'Error al obtener miembros');
+  }
+};
+
+export const addProjectMember = async (projectId, userId) => {
+  try {
+    return await apiClient.post(`/projects/${projectId}/members`, { user_id: userId });
+  } catch (error) {
+    throw new Error(error.response?.data?.detail || 'Error al agregar miembro');
+  }
+};
+
+export const removeProjectMember = async (projectId, userId) => {
+  try {
+    return await apiClient.delete(`/projects/${projectId}/members/${userId}`);
+  } catch (error) {
+    throw new Error(error.response?.data?.detail || 'Error al eliminar miembro');
+  }
+};


### PR DESCRIPTION
- Add Project and ProjectMember models, migration, and CRUD
- Add project endpoints: CRUD + member management
- Add project_id filter to information systems listing
- Add PUT /information_systems/{id} for project reassignment
- Add frontend: ProjectManager, ProjectMembersManager, ProjectCombobox
- Integrate project selector in CreateInformationSystem and Analysis views
- Add /projects route to navigation (analyst/admin)
- Add i18n keys for projects in es.json and en.json
- Fix JSONResponse import in error handlers
- Fix Alembic migration chain (add_diagram_input_type down_revision)
- Add test suites: test_projects_endpoints, test_project_members_endpoints
- Update test_information_system_endpoints for new PUT endpoint behavior